### PR TITLE
CVE QWG Vendor/Product/Version/Status information in prose

### DIFF
--- a/script.js
+++ b/script.js
@@ -186,28 +186,29 @@ function versionStatusTable5(affected) {
                     showCols[v.status] = true;
                     if(!v.changes) {
                         if(v.lessThan) {
-                            rows[v.status].push('>= ' + v.version + ' to < ' + v.lessThan);
+                            rows[v.status].push('from ' + v.version + ' before ' + v.lessThan);
                         } else if(v.lessThanOrEqual) {
-                            rows[v.status].push('>= ' + v.version + ' to <= ' + v.lessThanOrEqual);
+                            rows[v.status].push('from ' + v.version + ' through ' + v.lessThanOrEqual);
                         } else {
-                            rows[v.status].push('= ' + v.version);
+                            rows[v.status].push(v.version);
                         }
                     } else {
                         var prevStatus = v.status;
                         var prevVersion = v.version;
+			showCols[prevStatus] = true;
+                        if(v.lessThan) {
+                            rows[prevStatus].push('from ' + prevVersion + (v.lessThan != prevVersion ? ' before ' + v.lessThan : ''));
+                        } else if(v.lessThanOrEqual) {
+                            rows[prevStatus].push('from ' + prevVersion + (v.lessThanOrEqual != prevVersion ? ' before ' + v.lessThanOrEqual : ''));
+                        } else {
+                            rows[prevStatus].push(prevVersion);
+                        }
                         for(c of v.changes) {
                             showCols[c.status] = true;
-                            rows[prevStatus].push('>= ' + prevVersion + ' to < ' + c.at);
+                            rows[c.status].push('(at ' + c.at + ' transitions to ' + c.status + ')');
                             prevStatus = c.status;
                             prevVersion = c.at;
-                        }
-                        if(v.lessThan) {
-                            rows[prevStatus].push('>= ' + prevVersion + (v.lessThan != prevVersion ? ' to < ' + v.lessThan : ''));
-                        } else if(v.lessThanOrEqual) {
-                            rows[prevStatus].push('>= ' + prevVersion + (v.lessThanOrEqual != prevVersion ? ' to < ' + v.lessThanOrEqual : ''));
-                        } else {
-                            rows[prevStatus].push(">=" + prevVersion);
-                        }                  
+                        }			
                     }
                 }
                 if(!t[pFullName]) t[pFullName] = [];
@@ -232,6 +233,7 @@ function versionStatusTable5(affected) {
     //console.log(t);
     return({groups:nameAndPlatforms, vals:t, show: showCols});
 }
+
 
 
 cvssDesc = {


### PR DESCRIPTION
Signed-off-by: Vijay Sarvepalli <vssarvepalli@cert.org>

This is follow-up to support for CVE QWG from CERT/CC.

- CVE QWG is planning to represent Affected products (Vendor/Product/Version/Status) information in a human-readable form at cve.org for [CVE v5 JSON records](https://github.com/CVEProject/cve-schema/blob/master/schema/v5.0/CVE_JSON_5.0_schema.json).  
- These records can adopt the CVE [**Key Details Phrasing**](https://www.cve.org/Resources/General/Key-Details-Phrasing.pdf ) document to adopt the right ways to express the Affected Products with their Status information. 
- Use `before` and `through` keywords to distinguish  `lessThan` (<) and `lessThanOrEqual`  (<=) Status information from CVE v5 JSON records
- Also adopt the use of Object value for `changes` in Status information to natural language paragraphs, such as `at 2.5.2, it transitions to unaffected` , `at 2.6.0 it transitions to affected`, and `at 2.6.3 it transitions to unaffected`

It looks like previous Seagram had a few bugs in handling `changes` -  hopefully fixed with this pull request. 

Below are some recommendations for QWG to consider also.

- Make the Status view cleaner/simpler and avoid waste of whitespace under each Vendor/Product combo - see example PViewer [https://democert.org/vulnogram/pview/](https://democert.org/vulnogram/pview/)  for a view.  
- I have used the word `from` to represent a beginning version instead of leaving it blank as suggested by the **Key Details Phrasing** document. It seems to read better.
- The above code (PViewer) uses a number of CSS classes to identify types of content "Status" vs "Product" and "VendorProduct" CSS designations so any viewer can customize the CSS to display and there is less confusion if a Version number specified by a Vendor is not distinguishable.
- CSS and/or JavaScript can also use expand/contract of Vendor/Product/Version trees and limit the number of listed to first n-lines.
- Recommend that the preferred order for displaying the Affected Products will start with `affected` as the initially listed Status information.

Thanks
Vijay 





